### PR TITLE
#80 - Implement get_module_config on BasicInfoModule

### DIFF
--- a/flare_portal/experiments/models/modules.py
+++ b/flare_portal/experiments/models/modules.py
@@ -138,6 +138,19 @@ class BasicInfoModule(BaseModule):
     collect_headphone_model = models.BooleanField(default=False)
     collect_headphone_label = models.BooleanField(default=False)
 
+    def get_module_config(self) -> constants.ModuleConfigType:
+        return constants.ModuleConfigType(
+            id=self.pk,
+            type=self.get_module_tag(),
+            config={
+                "collect_date_of_birth": self.collect_date_of_birth,
+                "collect_gender": self.collect_gender,
+                "collect_headphone_make": self.collect_headphone_make,
+                "collect_headphone_model": self.collect_headphone_model,
+                "collect_headphone_label": self.collect_headphone_label,
+            },
+        )
+
     def get_module_description(self) -> str:
         collecting = {
             "date of birth": self.collect_date_of_birth,

--- a/flare_portal/experiments/tests/test_models.py
+++ b/flare_portal/experiments/tests/test_models.py
@@ -13,6 +13,7 @@ from ..factories import (
     ProjectFactory,
 )
 from ..models import (
+    BaseModule,
     Experiment,
     FearConditioningData,
     FearConditioningModule,
@@ -185,3 +186,18 @@ class FearConditioningDataTest(TestCase):
                 ("rating", data.rating),
             ],
         )
+
+
+class ModuleTest(TestCase):
+    def test_required_methods(self) -> None:
+        # Check all BaseModule subclasses have the required methods
+        for subclass in BaseModule.__subclasses__():
+            with self.subTest(subclass.__name__):
+                get_module_config = getattr(subclass, "get_module_config", None)
+
+                # Check that subclass has its own implementation
+                self.assertNotEqual(
+                    BaseModule.get_module_config,
+                    get_module_config,
+                    "Missing `get_module_config` implementation",
+                )


### PR DESCRIPTION
[Codebase ticket #80](https://projects.torchbox.com/projects/flare-rebuild/tickets/80)

#### When applied this MR will...

Implement the `get_module_config` method on `BasicInfoModule`, fixing the issue with the configuration endpoint.

#### Please provide detail on the technical changes, if relevant

This method needed to be implemented in order for the configuration endpoint to generate the configuration.

#### Screenshots

#### Dev checklist

- [x] PR addresses all ACs
- [x] Added unit tests if necessary
- [x] Updated documentation if necessary
- [x] CI passes
- [ ] Code reviewed
