### PR TITLE
Return `help_text` in Criterion configuration

### DIFF
--- a/flare_portal/experiments/models/modules.py
+++ b/flare_portal/experiments/models/modules.py
@@ -242,6 +242,7 @@ class CriterionModule(BaseModule):
                 "questions": [
                     {
                         "id": question.pk,
+                        "help_text": question.help_text,
                         "question_text": question.question_text,
                         "required_answer": question.required_answer,
                         "required": question.required,


### PR DESCRIPTION
[Codebase ticket #59](https://projects.torchbox.com/projects/flare-rebuild/tickets/59)

#### When applied this MR will...

This is a quick PR to add `help_text` to the configuration object response.

#### Please provide detail on the technical changes, if relevant

n/a

#### Screenshots

n/a

#### Dev checklist

- [x] PR addresses all ACs
- [x] Added unit tests if necessary
- [x] Updated documentation if necessary
- [x] CI passes
- [ ] Code reviewed
