### PR TITLE
#108: Add missing ‘action_label’ field to API config for instructions module.

### DIFF
--- a/flare_portal/experiments/models/modules.py
+++ b/flare_portal/experiments/models/modules.py
@@ -349,6 +349,7 @@ class InstructionsModule(BaseModule):
                     {
                         "title": screen.title,
                         "body": screen.body,
+                        "action_label": screen.action_label
                     }
                     for screen in self.screens.all()
                 ],

--- a/flare_portal/experiments/models/modules.py
+++ b/flare_portal/experiments/models/modules.py
@@ -349,7 +349,7 @@ class InstructionsModule(BaseModule):
                     {
                         "title": screen.title,
                         "body": screen.body,
-                        "action_label": screen.action_label
+                        "action_label": screen.action_label,
                     }
                     for screen in self.screens.all()
                 ],


### PR DESCRIPTION
[Codebase ticket #108](https://projects.torchbox.com/projects/flare-rebuild/tickets/108)

#### When applied this MR will...

Add missing ‘action_label’ field to API config for instructions module.

#### Please provide detail on the technical changes, if relevant
n/a

#### Screenshots
n/a

#### Dev checklist

- [x] PR addresses all ACs
- [x] Added unit tests if necessary
- [x] Updated documentation if necessary
- [x] CI passes
- [x] Code reviewed
