### PR TITLE
Change current_module in export to be the module name not the ID

### DIFF
--- a/flare_portal/experiments/exports.py
+++ b/flare_portal/experiments/exports.py
@@ -276,6 +276,7 @@ class USUnpleasantnessDataExporter(DataExporter):
 class ParticipantSerializer(serializers.ModelSerializer):
     experiment_code = serializers.CharField(source="experiment.code")
     voucher = serializers.CharField(source="get_voucher_display")
+    current_module = serializers.SerializerMethodField()
 
     class Meta:
         model = Participant
@@ -293,6 +294,12 @@ class ParticipantSerializer(serializers.ModelSerializer):
             "current_trial_index",
             "reinforced_stimulus",
         ]
+
+    def get_current_module(self, obj: Participant) -> str:
+        if obj.current_module:
+            return obj.current_module.specific.get_module_title()
+
+        return ""
 
 
 class ParticipantExporter(Exporter):


### PR DESCRIPTION
[Codebase ticket #148](https://projects.torchbox.com/projects/flare-rebuild/tickets/148)

#### When applied this MR will...

This PR switches the export to use a serializer method that returns the `current_module` title instead of the id

#### Please provide detail on the technical changes, if relevant
n/a

#### Screenshots
n/a

#### Dev checklist

- [x] PR addresses all ACs
- [x] Added unit tests if necessary
- [x] Updated documentation if necessary
- [x] CI passes
- [ ] Code reviewed
