### PR TITLE
Fix 500 error when editing particpant list with over 1000 fields

### DIFF
--- a/flare_portal/settings/base.py
+++ b/flare_portal/settings/base.py
@@ -583,6 +583,11 @@ REST_FRAMEWORK = {
 }
 
 
+# Django security settings
+
+# Default is 1000, Temp solution to help prevent errors when editing large particpant lists
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
+
 # Auth settings
 
 AUTH_USER_MODEL = "users.User"

--- a/flare_portal/settings/base.py
+++ b/flare_portal/settings/base.py
@@ -585,7 +585,8 @@ REST_FRAMEWORK = {
 
 # Django security settings
 
-# Default is 1000, Temp solution to help prevent errors when editing large particpant lists
+# Default is 1000, Temp solution to help prevent errors when
+# editing large particpant lists
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
 
 # Auth settings


### PR DESCRIPTION
#### When applied this MR will...
Sets DATA_UPLOAD_MAX_NUMBER_FIELDS to ten thousand to avoid errors when editing the particpant list. Due to the current implimentation of the particpant list page using inline formsets, paginating this page (which would be a more correct approach) would take a long time (the form class causes some issues that prevent Django's Pagintor class from being a quick drop in solution). 

This would be a temporary fix until then.

#### Dev checklist

- [x] CI passes
- [x] Code reviewed
