### PR TITLE
Disable Sentry's APM

### DIFF
--- a/flare_portal/settings/base.py
+++ b/flare_portal/settings/base.py
@@ -403,10 +403,6 @@ if "SENTRY_DSN" in env and not (
     SENTRY_CONFIG = {
         "dsn": env["SENTRY_DSN"],
         "integrations": [DjangoIntegration()],
-        # Set traces_sample_rate to 1.0 to capture 100%
-        # of transactions for performance monitoring.
-        # We recommend adjusting this value in production,
-        "traces_sample_rate": 1.0,
         # If you wish to associate users to errors (assuming you are using
         # django.contrib.auth) you may enable sending PII data.
         "send_default_pii": True,


### PR DESCRIPTION
This massively increased our quota usage, as each request becomes its own event, including those from Prometheus.

We don't need Sentry's APM, as we use an alternative on our projects. Our other projects already have these keys removed anyway.

![image](https://user-images.githubusercontent.com/6527489/138287628-6fb5db8b-9e69-4c91-8325-f4bda914752b.png)
