### PR TITLE
Update get_researchers implementation

### DIFF
--- a/flare_portal/experiments/tests/test_models.py
+++ b/flare_portal/experiments/tests/test_models.py
@@ -40,7 +40,7 @@ class ProjectTest(TestCase):
         self.assertEqual(project.created_at, now)
         self.assertEqual(project.updated_at, now)
 
-    def test_get_researchers(self):
+    def test_get_researchers(self) -> None:
         project = ProjectFactory()
         researcher = UserFactory()
         project.researchers.set([researcher])
@@ -51,7 +51,7 @@ class ProjectTest(TestCase):
         self.assertIn(project.owner, queryset)
         self.assertIn(researcher, queryset)
 
-    def test_get_researchers_no_duplicates(self):
+    def test_get_researchers_no_duplicates(self) -> None:
         project = ProjectFactory()
         researcher = UserFactory()
         project.researchers.set([project.owner, researcher])

--- a/flare_portal/experiments/tests/test_models.py
+++ b/flare_portal/experiments/tests/test_models.py
@@ -40,6 +40,34 @@ class ProjectTest(TestCase):
         self.assertEqual(project.created_at, now)
         self.assertEqual(project.updated_at, now)
 
+    def test_get_researchers(self):
+        project = ProjectFactory()
+        researcher = UserFactory()
+        project.researchers.set([researcher])
+
+        queryset = project.get_researchers()
+
+        self.assertEqual(2, len(queryset))
+        self.assertIn(project.owner, queryset)
+        self.assertIn(researcher, queryset)
+
+    def test_get_researchers_no_duplicates(self):
+        project = ProjectFactory()
+        researcher = UserFactory()
+        project.researchers.set([project.owner, researcher])
+
+        queryset = project.get_researchers()
+
+        self.assertEqual(2, len(queryset))
+        self.assertIn(project.owner, queryset)
+        self.assertIn(researcher, queryset)
+
+        # There used to be a bug where this raises MultipleObjectsReturned
+        # error. That is what this test is testing.
+        owner = project.get_researchers().get(pk=project.owner_id)
+
+        self.assertEqual(owner, project.owner)
+
 
 class ExperimentTest(TestCase):
     def test_model(self) -> None:


### PR DESCRIPTION
[Codebase ticket #212](https://projects.torchbox.com/projects/flare-rebuild/tickets/212)

#### When applied this MR will...

Update the implementation of `get_researchers` to fix

#### Please provide detail on the technical changes, if relevant

There was a bug with the implementation that caused calling `.get(pk=project.owner_id)` on the resulting queryset to return `MultipleObjectsReturned` error.

#### Screenshots

#### Dev checklist

- [ ] PR addresses all ACs
- [ ] Added unit tests if necessary
- [ ] Updated documentation if necessary
- [ ] CI passes
- [ ] Code reviewed
